### PR TITLE
Fix issue 87

### DIFF
--- a/scripts/components/HotbarUI.js
+++ b/scripts/components/HotbarUI.js
@@ -508,6 +508,7 @@ class HotbarUI {
   _initializeFadeOut() {
     // Add mousemove listener to document
     document.addEventListener('mousemove', this._handleMouseMove);
+    document.addEventListener('dragover', this._handleMouseMove);
     
     // Set initial state
     this._updateFadeState(false);


### PR DESCRIPTION
Related Issue: https://github.com/BragginRites/bg3-inspired-hotbar/issues/87

Fixes:
- Fade out UI will now fade in when dragging over it.