### PR TITLE
v3.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [3.0.9] - 2025-05-07
 ### Fixed
 - [Foundry V13] Fix duplicated weapons set on switch. (Related Issues: [#161])
+- Fix bug with weapon container after drag & drop. (Related Issues: [#166])
 
 ### Features
 - Add a setting to disable Weapon Sets auto-equip. (Related Issue: [#158])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [3.0.8] - 2025-05-06
+## [3.0.9] - 2025-05-07
 ### Fixed
 - [Foundry V13] Fix duplicated weapons set on switch. (Related Issues: [#161])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
 - Add a setting to disable Weapon Sets auto-equip. (Related Issue: [#158])
+- Add a setting to show extra "filters" based on items with limited uses. Those extra filters can't hightlight or grey out hotbars items. (Related Issue: [#168])
 
 ## [3.0.8] - 2025-05-06
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## [3.0.8] - 2025-05-06
 ### Fixed
-- Fix potential bug with Weapon Container. (Related Issues: [#160], [#161])
+- [Foundry V13] Fix duplicated weapons set on switch. (Related Issues: [#161])
+
+## [3.0.8] - 2025-05-06
+### Fixed
+- Fix potential bug with Weapon Container. (Related Issues: [#160])
 
 ### Features
 - Add CTRL/ALT modifier on Initiative button. (Related Issue: [#158])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fix bug with weapon container after drag & drop. (Related Issues: [#166])
 
 ### Features
-- Add a setting to disable Weapon Sets auto-equip. (Related Issue: [#158])
+- Add a setting to disable Weapon Sets auto-equip. (Related Issue: [#164])
 - Add a setting to show extra "filters" based on items with limited uses. Those extra filters can't hightlight or grey out hotbars items. (Related Issue: [#168])
 
 ## [3.0.8] - 2025-05-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Fixed
 - [Foundry V13] Fix duplicated weapons set on switch. (Related Issues: [#161])
 
+### Features
+- Add a setting to disable Weapon Sets auto-equip. (Related Issue: [#158])
+
 ## [3.0.8] - 2025-05-06
 ### Fixed
 - Fix potential bug with Weapon Container. (Related Issues: [#160])

--- a/lang/en.json
+++ b/lang/en.json
@@ -254,6 +254,10 @@
             "Name": "Enable GM Hotbar",
             "Hint": "Show GM special hotbar when no or multiple tokens are selected."
         },
+        "EnableWeaponAutoEquip": {
+            "Name": "Enable Weapon Sets Auto-Equip",
+            "Hint": "If checked, selecting a token or switching between weapon sets will automatically equip or unequip items."
+        },
         "Menu": {
             "Global": {
                 "Name": "General settings",
@@ -286,6 +290,7 @@
                 "Label": "Configure Hotbars",
                 "Sub": {
                     "General": "General",
+                    "Weapon": "Weapon Sets",
                     "Common": "Common Actions",
                     "Other": "Other"
                 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -258,6 +258,10 @@
             "Name": "Enable Weapon Sets Auto-Equip",
             "Hint": "If checked, selecting a token or switching between weapon sets will automatically equip or unequip items."
         },
+        "HoverFilterShow": {
+            "Name": "Hotbar Filter on hover",
+            "Hint": "If checked, show Hotbar Filter only when hovering it."
+        },
         "Menu": {
             "Global": {
                 "Name": "General settings",
@@ -294,6 +298,9 @@
                     "Common": "Common Actions",
                     "Other": "Other"
                 }
+            },
+            "Filter": {
+                "Name": "Filter settings"
             },
             "Combat": {
                 "Name": "Common Actions settings",

--- a/lang/en.json
+++ b/lang/en.json
@@ -262,6 +262,10 @@
             "Name": "Hotbar Filter on hover",
             "Hint": "If checked, show Hotbar Filter only when hovering it."
         },
+        "ShowExtendedFilter": {
+            "Name": "Show Extended Filters",
+            "Hint": "If checked, show items with limited uses as Filter (no highlight/grey out)."
+        },
         "Menu": {
             "Global": {
                 "Name": "General settings",

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "bg3-inspired-hotbar",
   "title": "BG3 Inspired HUD",
   "description": "A custom, persistent, token-specific HUD inspired by Baldur's Gate 3's interface. Provides an intuitive and modern way to manage abilities, spells, and effects for your tokens.",
-  "version": "3.0.8",
+  "version": "3.0.9",
   "authors": [
     {
       "name": "BragginRites",
@@ -80,8 +80,8 @@
   },
   "persistentStorage": true,
   "url": "https://github.com/BragginRites/bg3-inspired-hotbar",
-  "manifest": "https://github.com/BragginRites/bg3-inspired-hotbar/releases/download/v3.0.8/module.json",
-  "download": "https://github.com/BragginRites/bg3-inspired-hotbar/releases/download/v3.0.8/bg3-inspired-hotbar.zip",
+  "manifest": "https://github.com/BragginRites/bg3-inspired-hotbar/releases/download/v3.0.9/module.json",
+  "download": "https://github.com/BragginRites/bg3-inspired-hotbar/releases/download/v3.0.9/bg3-inspired-hotbar.zip",
   "readme": "README.md",
   "bugs": "https://github.com/BragginRites/bg3-inspired-hotbar/issues",
   "packs": [

--- a/scripts/bg3-hotbar.js
+++ b/scripts/bg3-hotbar.js
@@ -331,8 +331,9 @@ export class BG3Hotbar extends Application {
         html.dataset.itemName = game.settings.get(BG3CONFIG.MODULE_NAME, 'showItemNames');
         html.dataset.itemUse = game.settings.get(BG3CONFIG.MODULE_NAME, 'showItemUses');
         html.dataset.cellHighlight = game.settings.get(BG3CONFIG.MODULE_NAME, 'highlightStyle');
+        html.dataset.cellHighlight = game.settings.get(BG3CONFIG.MODULE_NAME, 'highlightStyle');
+        html.dataset.filterHover = game.settings.get(BG3CONFIG.MODULE_NAME, 'hoverFilterShow');
         document.body.dataset.showMaterials = game.settings.get(BG3CONFIG.MODULE_NAME, 'showMaterialDescription');
-        document.body.dataset.lightTooltip = game.settings.get(BG3CONFIG.MODULE_NAME, 'enableLightTooltip');
         ControlsManager.updateUIDataset(html);
 
         if(this.manager.currentTokenId) {

--- a/scripts/bg3-hotbar.js
+++ b/scripts/bg3-hotbar.js
@@ -253,7 +253,7 @@ export class BG3Hotbar extends Application {
     }
 
     _autoPopulateToken(token) {
-        return AutoPopulateCreateToken.populateUnlinkedToken(token, true);
+        return AutoPopulateCreateToken.populateUnlinkedToken(token.document ?? token, true);
     }
 
     async _applyTheme() {

--- a/scripts/components/buttons/filterButton.js
+++ b/scripts/components/buttons/filterButton.js
@@ -43,6 +43,8 @@ export class FilterButton extends BG3Component {
                 desc = `<div class="custom-tooltip"><h4 style="--data-color:${this.data.color}">${label}</h4><p class="notes"><i>Left Click to highlight items using this slot.</i></p><p class="notes"><i>Right Click to grey out.</i></p></div>`; 
                 break;
             default:
+                // desc = this.data.custom?.tooltip ? `<div class="custom-tooltip dnd5e2"><h4 style="--data-color:${this.data.color}">${this.data.custom?.tooltip?.label}</h4>${this.data.custom?.tooltip?.pills ? `<ul class="pills">${this.data.custom.tooltip.pills.map(p => `<li class="pill"><span class="label" style="color: #4e4e4e;">${p}</label></li>`).join('')}</ul>` : ''}</div>` : false;
+                desc = this.data.custom?.tooltip ? `<div class="custom-tooltip dnd5e2"><h4 style="--data-color:${this.data.color}">${this.data.custom?.tooltip?.label}</h4></div>` : false;
                 break;
         }
         return {type: 'simple', content: desc};
@@ -51,12 +53,13 @@ export class FilterButton extends BG3Component {
     async _registerEvents() {
         this.element.addEventListener("click", (e) => {
             e.preventDefault();
-            if(this._parent.used.includes(this)) return;
+            if(this.data.custom || this._parent.used.includes(this)) return;
             this._parent.highlighted = this;
         });
 
         this.element.addEventListener("contextmenu", (e) => {
             e.preventDefault();
+            if(this.data.custom) return;
             this._parent.used = this;
         });
     }
@@ -64,6 +67,7 @@ export class FilterButton extends BG3Component {
     async render() {
         await super.render();
         this.element.style.color = this.data.color;
+        if(this.data.background) this.element.style.backgroundImage = `url(${this.data.background})`;
         return this.element;
     }
 }

--- a/scripts/components/containers/FilterContainer.js
+++ b/scripts/components/containers/FilterContainer.js
@@ -197,12 +197,63 @@ export class FilterContainer extends BG3Component {
         if((ui.BG3HOTBAR.components.container.components.activeContainer.activesList.find(a => a._id === 'dnd5ereaction000') && !this.used.includes(reactionFilter)) || (!ui.BG3HOTBAR.components.container.components.activeContainer.activesList.find(a => a._id === 'dnd5ereaction000') && this.used.includes(reactionFilter))) this.used = reactionFilter;
     }
 
+    async getExtendedFilter() {
+        if(!game.settings.get(BG3CONFIG.MODULE_NAME, 'showExtendedFilter')) return;
+        const resources = [],
+            color = '#d5a25b';
+        for(const item of this.actor.items) {
+            if(item.hasLimitedUses) {
+                resources.push(new FilterButton({
+                    color: color,
+                    class: ['filter-spell-point', 'filter-custom'],
+                    background: item.img,
+                    custom: {
+                        value: item.system.uses.value,
+                        max: item.system.uses.max,
+                        tooltip: {
+                            label: item.name,
+                            // pills: item.system.requirements ? item.system.requirements.split(';') : null
+                        }
+                    }
+                }, this));
+            }
+        }
+        for(const resourceId in this.actor.system.resources) {
+            const oResource = this.actor.system.resources[resourceId];
+            if(oResource.value && oResource.label !== '') {
+                resources.push(new FilterButton({
+                    color: color,
+                    class: ['filter-spell-point', 'filter-custom'],
+                    background: null,
+                    custom: {
+                        value: oResource.value,
+                        max: oResource.max,
+                        tooltip: {
+                            label: oResource.label
+                        }
+                    }
+                }, this));
+            }
+        }
+        await Promise.all(resources.map(async (filter) => {
+            this.element.appendChild(filter.element);
+            await filter.render();
+        }));
+    }
+
+    async updateExtendedFilter() {
+        $(this.element).find('.filter-custom').remove();
+        await this.getExtendedFilter();
+    }
+
     async render() {
         await super.render();
         
         this.components = this.filterData.map((filter) => new FilterButton(filter, this));
         for(const filter of this.components) this.element.appendChild(filter.element);
         await Promise.all(this.components.map((filter) => filter.render()));
+
+        await this.getExtendedFilter();
 
         return this.element;
     }

--- a/scripts/components/containers/WeaponContainer.js
+++ b/scripts/components/containers/WeaponContainer.js
@@ -1,5 +1,4 @@
 import { BG3CONFIG } from "../../utils/config.js";
-import { fromUuid } from "../../utils/foundryUtils.js";
 import { BG3Component } from "../component.js";
 import { GridContainer } from "./GridContainer.js";
 

--- a/scripts/components/containers/WeaponContainer.js
+++ b/scripts/components/containers/WeaponContainer.js
@@ -1,4 +1,5 @@
 import { BG3CONFIG } from "../../utils/config.js";
+import { fromUuid } from "../../utils/foundryUtils.js";
 import { BG3Component } from "../component.js";
 import { GridContainer } from "./GridContainer.js";
 
@@ -61,47 +62,13 @@ export class WeaponContainer extends BG3Component {
         // Update active set & equipped items
         this.activeSet = c.index;
         c.oldWeapons = foundry.utils.deepClone(c.data.items);
-        if(toUpdate.length) await this.actor.updateEmbeddedDocuments("Item", toUpdate);
-    }
-
-    /* async switchSet2(c) {
-        if(c.index === this.activeSet && c.oldWeapons === c.data.items) return;
-
-        const weaponsList = this.actor.items.filter(w => w.type == 'weapon'),
-            toUpdate = [];
-        if(this.activeSet !== c.index) {
-            // Add previous set to unequip
-            Object.values(this.components.weapon[this.activeSet].data.items).forEach(w => {
-              toUpdate.push({_id: w.uuid.split('.').pop(), "system.equipped": 0});
-            });
-      
-            // Save new active set
-            this.activeSet = c.index;
-            await ui.BG3HOTBAR.manager.persist();
-        } else if(c.oldWeapons && c.oldWeapons !== c.data.items) {
-            Object.values(c.oldWeapons).forEach(w => {
-              toUpdate.push({_id: w.uuid.split('.').pop(), "system.equipped": 0});
-            });
-        }
-        c.oldWeapons = foundry.utils.deepClone(c.data.items);
-        if(Object.values(c.data.items).length) {
-          Object.values(c.data.items).forEach(w => {
-            const itemId =  w.uuid.split('.').pop(),
-              commonItem = toUpdate.findIndex(wu => wu._id == itemId);
-            if(commonItem > -1) toUpdate[commonItem]["system.equipped"] = 1;
-            else toUpdate.push({_id: itemId, "system.equipped": 1})
-          })
-        }
-        weaponsList.forEach(w => {
-            if(w.system.equipped) {
-                const itemIndex = toUpdate.findIndex(wu => wu._id == w.id);
-                if(itemIndex === -1) toUpdate.push({_id: w.id, "system.equipped": 0});
-                else toUpdate.splice(itemIndex, 1);
+        if(toUpdate.length) {
+            for(const update of toUpdate) {
+                const item = this.actor.items.get(update._id);
+                if(item) item.updateSource({"system.equipped": update["system.equipped"]})
             }
-            // if(w.system.equipped && !toUpdate.find(wu => wu._id == w.id)) toUpdate.push({_id: w.id, "system.equipped": 0})
-        })
-        if(toUpdate.length) await this.actor.updateEmbeddedDocuments("Item", toUpdate);
-    } */
+        }
+    }
 
     async render() {
         await super.render();

--- a/scripts/components/containers/WeaponContainer.js
+++ b/scripts/components/containers/WeaponContainer.js
@@ -40,19 +40,21 @@ export class WeaponContainer extends BG3Component {
                 compareOld = c.index === this.activeSet ? c.oldWeapons : this.components.weapon[this.activeSet].data.items;
             let toUpdate = [];
             weaponsList.forEach(w => {
-                if(w.system.equipped && !Object.values(c.data.items).find(wc => w.id === wc.uuid.split('.').pop())) {
+                if(w.system.equipped && !Object.values(c.data.items).find(wc => wc?.uuid && w.id === wc.uuid.split('.').pop())) {
                     toUpdate.push({_id: w.id, "system.equipped": 0});
-                } else if(!w.system.equipped && Object.values(c.data.items).find(wc => w.id === wc.uuid.split('.').pop())) {
+                } else if(!w.system.equipped && Object.values(c.data.items).find(wc => wc?.uuid && w.id === wc.uuid.split('.').pop())) {
                     toUpdate.push({_id: w.id, "system.equipped": 1});
                 }
             });
             Object.values(c.data.items).forEach(nw => {
+                if(!nw?.uuid) return;
                 const itemId = nw.uuid.split('.').pop(),
                     item = this.actor.items.get(itemId);
                 if(item && item.type !== 'weapon' && !item.system.equipped) toUpdate.push({_id: itemId, "system.equipped": 1});
             });
             if(compareOld) {
                 Object.values(compareOld).forEach(ow => {
+                    if(!ow?.uuid) return;
                     const itemId = ow.uuid.split('.').pop(),
                         item = this.actor.items.get(itemId);
                     if(item && item.type !== 'weapon' && item.system.equipped && !Object.values(c.data.items).find(w => w.uuid === ow.uuid)) toUpdate.push({_id: itemId, "system.equipped": 0});

--- a/scripts/managers/ItemUpdateManager.js
+++ b/scripts/managers/ItemUpdateManager.js
@@ -226,6 +226,7 @@ export class ItemUpdateManager {
         if (needSave) {
             // Save the changes
             await ui.BG3HOTBAR.manager.persist();
+            await ui.BG3HOTBAR.components.container.components.filterContainer.updateExtendedFilter();
         }
     }
     
@@ -305,6 +306,7 @@ export class ItemUpdateManager {
         for (const container of ui.BG3HOTBAR.components.container.components.hotbar) {
             let hasChanges = false;
             for (const [slot, item] of Object.entries(container.data.items)) {
+                if(!item.uuid) continue;
                 const itemData = await fromUuid(item.uuid);
                 if(itemData?.documentName == 'Macro' || itemData?.documentName == 'Activity') continue;
                 

--- a/scripts/utils/config.js
+++ b/scripts/utils/config.js
@@ -478,7 +478,7 @@ export function updateSettingsDisplay() {
                 categories: [
                     {
                         label: null,
-                        fields: ['hoverFilterShow']
+                        fields: ['hoverFilterShow', 'showExtendedFilter']
                     }
                 ]
             },
@@ -1127,6 +1127,20 @@ export function registerSettings() {
         onChange: value => {
             if (ui.BG3HOTBAR.element?.[0]) {
                 ui.BG3HOTBAR.element[0].dataset.filterHover = value;
+            }
+        }
+    });
+
+    game.settings.register(BG3CONFIG.MODULE_NAME, 'showExtendedFilter', {
+        name: 'BG3.Settings.ShowExtendedFilter.Name',
+        hint: 'BG3.Settings.ShowExtendedFilter.Hint',
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: false,
+        onChange: () => {
+            if (ui.BG3HOTBAR.components?.container?.components?.filterContainer) {
+                ui.BG3HOTBAR.components.container.components.filterContainer.updateExtendedFilter();
             }
         }
     });

--- a/scripts/utils/config.js
+++ b/scripts/utils/config.js
@@ -460,6 +460,10 @@ export function updateSettingsDisplay() {
                         fields: ['showItemNames', 'showItemUses', 'highlightStyle']
                     },
                     {
+                        label: 'BG3.Settings.Menu.Hotbar.Sub.Weapon',
+                        fields: ['enableWeaponAutoEquip']
+                    },
+                    {
                         label: 'BG3.Settings.Menu.Hotbar.Sub.Common',
                         fields: ['showCombatContainer', 'autoPopulateCombatContainer', 'chooseCPRActions', 'lockCombatContainer']
                     },
@@ -938,6 +942,7 @@ export function registerSettings() {
         default: false
     });
 
+    // Hotbar Settings
     game.settings.register(BG3CONFIG.MODULE_NAME, 'showItemNames', {
         name: 'Show Item Names',
         hint: 'Display item names below each hotbar item',
@@ -982,6 +987,15 @@ export function registerSettings() {
                 ui.BG3HOTBAR.element[0].dataset.cellHighlight = value;
             }
         }
+    });
+
+    game.settings.register(BG3CONFIG.MODULE_NAME, 'enableWeaponAutoEquip', {
+        name: 'BG3.Settings.EnableWeaponAutoEquip.Name',
+        hint: 'BG3.Settings.EnableWeaponAutoEquip.Hint',
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: true
     });
 
     game.settings.register(BG3CONFIG.MODULE_NAME, 'showCombatContainer', {

--- a/scripts/utils/config.js
+++ b/scripts/utils/config.js
@@ -474,6 +474,15 @@ export function updateSettingsDisplay() {
                 ]
             },
             {
+                label: 'BG3.Settings.Menu.Filter.Name',
+                categories: [
+                    {
+                        label: null,
+                        fields: ['hoverFilterShow']
+                    }
+                ]
+            },
+            {
                 label: 'BG3.Settings.Menu.Populate.Name',
                 categories: [
                     {
@@ -1107,6 +1116,22 @@ export function registerSettings() {
         type: Boolean,
         default: false
     });
+
+    game.settings.register(BG3CONFIG.MODULE_NAME, 'hoverFilterShow', {
+        name: 'BG3.Settings.HoverFilterShow.Name',
+        hint: 'BG3.Settings.HoverFilterShow.Hint',
+        scope: 'client',
+        config: true,
+        type: Boolean,
+        default: true,
+        onChange: value => {
+            if (ui.BG3HOTBAR.element?.[0]) {
+                ui.BG3HOTBAR.element[0].dataset.filterHover = value;
+            }
+        }
+    });
+
+    // Filter Settings
 
     // Auto-Population Settings
     game.settings.register(BG3CONFIG.MODULE_NAME, 'enforceSpellPreparationPC', {

--- a/styles/components/filter.css
+++ b/styles/components/filter.css
@@ -32,9 +32,13 @@
     transition: all 0.2s ease;
 }
 
+#bg3-hotbar-container .bg3-filter-subcontainer > div {
+ /*    
+}
+
 #bg3-hotbar-container .action-type-button,
 #bg3-hotbar-container .feature-button,
-#bg3-hotbar-container .spell-level-button {
+#bg3-hotbar-container .spell-level-button { */
     width: var(--bg3-filter-cell-size);
     height: var(--bg3-filter-cell-size);
     display: flex;
@@ -156,4 +160,13 @@
     top: 50%;
     transform: translateY(-50%);
     pointer-events: none;
+}
+
+#bg3-hotbar-container .filter-spell-point.filter-custom {
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
+#bg3-hotbar-container .filter-spell-point.filter-custom  .spell-level-label {
+    /* font-size: 20px; */
 }

--- a/styles/components/filter.css
+++ b/styles/components/filter.css
@@ -15,7 +15,14 @@
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
     margin-bottom: 1px;
     transition: all 0.2s ease;
+}
+
+#bg3-hotbar-container[data-filter-hover="true"] .bg3-hotbar-container .bg3-filter-subcontainer {
     opacity: 0;
+}
+
+#bg3-hotbar-container[data-filter-hover="true"] .bg3-hotbar-container:hover .bg3-filter-subcontainer {
+    opacity: 1;
 }
 
 #bg3-hotbar-container .filter-content {
@@ -106,8 +113,8 @@
     border-width: var(--bg3-filter-border-size);
     border-style: solid;
     box-sizing: border-box;
-    width: 11px;
-    height: 11px;
+    width: 10px;
+    height: 10px;
     background-color: currentColor;
 }
 

--- a/styles/components/hotbar.css
+++ b/styles/components/hotbar.css
@@ -221,6 +221,7 @@
     font-weight: bold;
     z-index: 11;
     pointer-events: none;
+    text-shadow: var(--shadow-text-stroke);
 }
 
 #bg3-hotbar-container .hotbar-item-uses.depleted {

--- a/styles/components/hotbar.css
+++ b/styles/components/hotbar.css
@@ -27,10 +27,6 @@
     /* width: calc(var(--cols) * (var(--bg3-hotbar-cell-size) + 4px) + 8px); */
 }
 
-#bg3-hotbar-container .bg3-hotbar-container:hover .bg3-filter-subcontainer {
-    opacity: 1;
-}
-
 /* ==========================================================================
    Drag Bar
    ========================================================================== */

--- a/templates/components/FilterButton.hbs
+++ b/templates/components/FilterButton.hbs
@@ -6,4 +6,5 @@
         {{/times}}
     {{/if}}
     {{#if short}}<div class="spell-level-label">{{short}}</div>{{/if}}
+    {{#if custom}}<div class="spell-level-label custom-filter-btn">{{custom.value}}/{{custom.max}}</div>{{/if}}
 </div>


### PR DESCRIPTION
## [3.0.9] - 2025-05-07
### Fixed
- [Foundry V13] Fix duplicated weapons set on switch. (Related Issues: [#161])
- Fix bug with weapon container after drag & drop. (Related Issues: [#166])

### Features
- Add a setting to disable Weapon Sets auto-equip. (Related Issue: [#164])
- Add a setting to show extra "filters" based on items with limited uses. Those extra filters can't hightlight or grey out hotbars items. (Related Issue: [#168])