### PR TITLE
v3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [3.1.2] - 2025-05-07
+## [3.1.3] - 2025-05-12
+### Fixed
+- Fix Hide Macrobar logic.
+
+## [3.1.2] - 2025-05-11
 ### Fixed
 - Fix UI sometimes displayed to the top of the screen (with camera activated for example). (Related Issues: [#179])
 - Limit "Extra Filters" to items with the "feat" type. (Related Issues: [#182])
@@ -6,7 +10,7 @@
 ### Features
 - Patch DnD 5e Tooltip method to display charges for items without the "identified" property. Also non-identified items won't display their charges in hotbar anymore. (Related Issues: [#180])
 
-## [3.1.1] - 2025-05-07
+## [3.1.1] - 2025-05-10
 ### Fixed
 - Auto select HP in HP Control input to allow faster editing.
 - Fix a bug when deactivating "Show Damage as Ranges" setting.
@@ -14,7 +18,7 @@
 ### Features
 - Add new parameter in Right-Click Portrait Menu to scale Token Image based of Token Scale (Ratio). (Related Issues: [#163])
 
-## [3.1.0] - 2025-05-07
+## [3.1.0] - 2025-05-09
 ### Fixed
 - [Foundry V13] Fix saving throw new method name. (Related Issues: [#173])
 - [Foundry V13] Fix "Collapse Macro" setting, it can't be collapsed anymore since V13.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-## [3.1.3] - 2025-05-12
+## [3.1.3] - 2025-05-13
 ### Fixed
 - Fix Hide Macrobar logic.
 - Fix HP Controls removing temp HP. (Related Issues: [#184])
 - Allow players with permission to see HP Controls. (Related Issues: [#184])
+
+### Features
+- Add a option in Controls Container to "lock" the GM Hotbar to keep it even after selecting a token. (Related Issues: [#185])
 
 ## [3.1.2] - 2025-05-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [3.1.3] - 2025-05-12
 ### Fixed
 - Fix Hide Macrobar logic.
+- Fix HP Controls removing temp HP. (Related Issues: [#184])
+- Allow players with permission to see HP Controls. (Related Issues: [#184])
 
 ## [3.1.2] - 2025-05-11
 ### Fixed

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "id": "bg3-inspired-hotbar",
   "title": "BG3 Inspired HUD",
   "description": "A custom, persistent, token-specific HUD inspired by Baldur's Gate 3's interface. Provides an intuitive and modern way to manage abilities, spells, and effects for your tokens.",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "authors": [
     {
       "name": "BragginRites",
@@ -80,8 +80,8 @@
   },
   "persistentStorage": true,
   "url": "https://github.com/BragginRites/bg3-inspired-hotbar",
-  "manifest": "https://github.com/BragginRites/bg3-inspired-hotbar/releases/download/v3.1.2/module.json",
-  "download": "https://github.com/BragginRites/bg3-inspired-hotbar/releases/download/v3.1.2/bg3-inspired-hotbar.zip",
+  "manifest": "https://github.com/BragginRites/bg3-inspired-hotbar/releases/download/v3.1.3/module.json",
+  "download": "https://github.com/BragginRites/bg3-inspired-hotbar/releases/download/v3.1.3/bg3-inspired-hotbar.zip",
   "readme": "README.md",
   "bugs": "https://github.com/BragginRites/bg3-inspired-hotbar/issues",
   "packs": [

--- a/scripts/bg3-hotbar.js
+++ b/scripts/bg3-hotbar.js
@@ -111,15 +111,18 @@ export class BG3Hotbar extends Application {
             this.generateTimeout = null;
         }
 
-        this.generateTimeout = setTimeout(() => {
+        this.generateTimeout = setTimeout(async () => {
             if (((!controlled && !canvas.tokens.controlled.length) || canvas.tokens.controlled.length > 1) && !ControlsManager.isSettingLocked('deselect')) {
                 if (!canvas.tokens.controlled.length || canvas.tokens.controlled.length > 1) this.generate(null);
             }
-            if (!controlled || !canvas.tokens.controlled.length || canvas.tokens.controlled.length > 1) return;
+            if (!controlled || !canvas.tokens.controlled.length || canvas.tokens.controlled.length > 1) {
+                // if(game.settings.get(BG3CONFIG.MODULE_NAME, 'collapseFoundryMacrobar') === 'select') this._applyMacrobarCollapseSetting();
+                return;
+            }
 
             if(game.settings.get(BG3CONFIG.MODULE_NAME, 'uiEnabled')) {
-                this.generate(token);
-                if(game.settings.get(BG3CONFIG.MODULE_NAME, 'collapseFoundryMacrobar') === 'select') this._applyMacrobarCollapseSetting();
+                await this.generate(token);
+                // if(game.settings.get(BG3CONFIG.MODULE_NAME, 'collapseFoundryMacrobar') === 'select') this._applyMacrobarCollapseSetting();
             }
         })
     }
@@ -229,30 +232,30 @@ export class BG3Hotbar extends Application {
     }
 
     _applyMacrobarCollapseSetting() {
-            // We need to wait for the UI to be ready before collapsing the hotbar
-            if (!ui.hotbar) {
-                // UI not ready, deferring macrobar collapse
-                Hooks.once('renderHotbar', () => this._applyMacrobarCollapseSetting());
-                return;
-            }
-            
-            const collapseMacrobar = game.settings.get(BG3CONFIG.MODULE_NAME, 'collapseFoundryMacrobar');
-            if(collapseMacrobar !== 'full' && document.querySelector("#hotbar").style.display != 'flex') document.querySelector("#hotbar").style.display = 'flex';
-            // Applying macrobar collapse setting
-            if (collapseMacrobar === 'always' || collapseMacrobar === 'true') {
+        // We need to wait for the UI to be ready before collapsing the hotbar
+        if (!ui.hotbar) {
+            // UI not ready, deferring macrobar collapse
+            Hooks.once('renderHotbar', () => this._applyMacrobarCollapseSetting());
+            return;
+        }
+        
+        const collapseMacrobar = game.settings.get(BG3CONFIG.MODULE_NAME, 'collapseFoundryMacrobar');
+        if(collapseMacrobar !== 'full' && document.querySelector("#hotbar").style.display != 'flex') document.querySelector("#hotbar").style.display = 'flex';
+        // Applying macrobar collapse setting
+        if (collapseMacrobar === 'always' || collapseMacrobar === 'true') {
+            this.isV13orHigher() ? ui.hotbar.element.classList.add('hidden') : ui.hotbar.collapse();
+        } else if (collapseMacrobar === 'never' || collapseMacrobar === 'false') {
+            this.isV13orHigher() ? ui.hotbar.element.classList.remove('hidden') : ui.hotbar.expand();
+        } else if(collapseMacrobar === 'select') {
+            if(this.macroBarTimeout) clearTimeout(this.macroBarTimeout);
+            if(ui.BG3HOTBAR?._element) {
                 this.isV13orHigher() ? ui.hotbar.element.classList.add('hidden') : ui.hotbar.collapse();
-            } else if (collapseMacrobar === 'never' || collapseMacrobar === 'false') {
-                this.isV13orHigher() ? ui.hotbar.element.classList.remove('hidden') : ui.hotbar.expand();
-            } else if(collapseMacrobar === 'select') {
-                if(this.macroBarTimeout) clearTimeout(this.macroBarTimeout);
-                if(!!ui.BG3HOTBAR?.element) {
-                    this.isV13orHigher() ? ui.hotbar.element.classList.add('hidden') : ui.hotbar.collapse();
-                } else {
-                    this.macroBarTimeout = setTimeout(() => {
-                        this.isV13orHigher() ? ui.hotbar.element.classList.remove('hidden') : ui.hotbar.expand();
-                    }, 100);
-                }
-            } else if(collapseMacrobar === 'full' && document.querySelector("#hotbar").style.display != 'none') document.querySelector("#hotbar").style.display = 'none';
+            } else {
+                this.macroBarTimeout = setTimeout(() => {
+                    this.isV13orHigher() ? ui.hotbar.element.classList.remove('hidden') : ui.hotbar.expand();
+                }, 100);
+            }
+        } else if(collapseMacrobar === 'full' && document.querySelector("#hotbar").style.display != 'none') document.querySelector("#hotbar").style.display = 'none';
     }
 
     _autoPopulateToken(token) {
@@ -304,7 +307,11 @@ export class BG3Hotbar extends Application {
         if (!this.manager) return;
         if(!token) {
             this.manager.currentTokenId = null;
-            if(!this.manager.canGMHotbar()) return this.close();
+            if(!this.manager.canGMHotbar()) {
+                await this.close();
+                if(game.settings.get(BG3CONFIG.MODULE_NAME, 'collapseFoundryMacrobar') === 'select') this._applyMacrobarCollapseSetting();
+                return;
+            }
         } else this.manager.currentTokenId = token.id;
         this.manager._loadTokenData();
         this.render(true);
@@ -312,8 +319,8 @@ export class BG3Hotbar extends Application {
 
     async _render(force=false, options={}) {
         await super._render(force, options);
-        
         if(this.components?.container?.components?.filterContainer) this.components.container.components.filterContainer._checkBonusReactionUsed();
+        if(game.settings.get(BG3CONFIG.MODULE_NAME, 'collapseFoundryMacrobar') === 'select') this._applyMacrobarCollapseSetting();
     }
 
     async _renderInner(data) {        

--- a/scripts/bg3-hotbar.js
+++ b/scripts/bg3-hotbar.js
@@ -111,19 +111,14 @@ export class BG3Hotbar extends Application {
             this.generateTimeout = null;
         }
 
+        if(this.manager.canGMHotbar() && ControlsManager.isSettingLocked('deselect')) return;
         this.generateTimeout = setTimeout(async () => {
             if (((!controlled && !canvas.tokens.controlled.length) || canvas.tokens.controlled.length > 1) && !ControlsManager.isSettingLocked('deselect')) {
                 if (!canvas.tokens.controlled.length || canvas.tokens.controlled.length > 1) this.generate(null);
             }
-            if (!controlled || !canvas.tokens.controlled.length || canvas.tokens.controlled.length > 1) {
-                // if(game.settings.get(BG3CONFIG.MODULE_NAME, 'collapseFoundryMacrobar') === 'select') this._applyMacrobarCollapseSetting();
-                return;
-            }
+            if (!controlled || !canvas.tokens.controlled.length || canvas.tokens.controlled.length > 1) return;
 
-            if(game.settings.get(BG3CONFIG.MODULE_NAME, 'uiEnabled')) {
-                await this.generate(token);
-                // if(game.settings.get(BG3CONFIG.MODULE_NAME, 'collapseFoundryMacrobar') === 'select') this._applyMacrobarCollapseSetting();
-            }
+            if(game.settings.get(BG3CONFIG.MODULE_NAME, 'uiEnabled')) await this.generate(token);
         })
     }
 

--- a/scripts/components/containers/ControlContainer.js
+++ b/scripts/components/containers/ControlContainer.js
@@ -191,7 +191,7 @@ export class ControlContainer extends BG3Component {
             closeParent: true,
             buttons: {
                 deselect: {
-                    label: 'Deselecting Token',
+                    label: ui.BG3HOTBAR.manager.canGMHotbar() ? 'Keep GM Hotbar' : 'Deselecting Token',
                     icon: 'fas fa-user-slash',
                     class: ControlsManager.getLockSetting('deselect') ? 'checked' : '',
                     custom: '<div class="menu-item-checkbox "><i class="fas fa-check"></i></div>',

--- a/scripts/components/containers/PortraitHealth.js
+++ b/scripts/components/containers/PortraitHealth.js
@@ -17,7 +17,7 @@ export class PortraitHealth extends BG3Component {
         return {
             enabled: game.settings.get(BG3CONFIG.MODULE_NAME, 'showHPText'),
             health: this._parent.health,
-            hpControls: game.settings.get(BG3CONFIG.MODULE_NAME, 'enableHPControls') && game.user.isGM
+            hpControls: game.settings.get(BG3CONFIG.MODULE_NAME, 'enableHPControls') && ui.BG3HOTBAR.manager.actor?.canUserModify(game.user, "update")
         };
     }
 
@@ -97,7 +97,7 @@ export class PortraitHealth extends BG3Component {
 
     async render() {
         await super.render();
-        if(!game.settings.get(BG3CONFIG.MODULE_NAME, 'enableHPControls') || !game.user.isGM) this.element.style.setProperty('pointer-events', 'none');
+        if(!game.settings.get(BG3CONFIG.MODULE_NAME, 'enableHPControls') || !ui.BG3HOTBAR.manager.actor.canUserModify(game.user, "update")) this.element.style.setProperty('pointer-events', 'none');
         else this.element.style.removeProperty('pointer-events');
         return this.element;
     }

--- a/templates/components/PortraitHealth.hbs
+++ b/templates/components/PortraitHealth.hbs
@@ -6,7 +6,7 @@
             <div class="hp-controls">
                 <div class="hp-control-death"><i class="fas fa-skull" data-tooltip="{{localize "BG3.Portrait.HP.Death"}}"></i></div>
                 {{!-- <div class="hp-control-minus"><i class="fas fa-circle-minus"></i></div> --}}
-                <input class="hp-input" type="text" value="{{health.current}}" max="{{health.max}}">
+                <input class="hp-input" type="text" value="{{math health.current '+' health.temp}}" max="{{health.max}}">
                 {{!-- <div class="hp-control-plus"><i class="fas fa-circle-plus"></i></div> --}}
                 <div class="hp-control-full"><i class="fas fa-heart" data-tooltip="{{localize "BG3.Portrait.HP.Full"}}"></i></div>
             </div>


### PR DESCRIPTION
## [3.1.3] - 2025-05-13
### Fixed
- Fix Hide Macrobar logic.
- Fix HP Controls removing temp HP. (Related Issues: [#184])
- Allow players with permission to see HP Controls. (Related Issues: [#184])

### Features
- Add a option in Controls Container to "lock" the GM Hotbar to keep it even after selecting a token. (Related Issues: [#185])