### PR TITLE
Extend action type filters to search activities

### DIFF
--- a/scripts/components/containers/FilterContainer.js
+++ b/scripts/components/containers/FilterContainer.js
@@ -158,7 +158,7 @@ export class FilterContainer extends BG3Component {
             case 'feature':
                 return cell.dataset.itemType === 'feat';
             default:
-                return filter.data.id === cell.dataset.actionType;
+                return filter.data.id === cell.dataset.actionType || cell.dataset.activityActionTypes?.split(',').includes(filter.data.id);
         }
     }
         
@@ -258,3 +258,4 @@ export class FilterContainer extends BG3Component {
         return this.element;
     }
 }
+

--- a/scripts/components/containers/GridCell.js
+++ b/scripts/components/containers/GridCell.js
@@ -327,6 +327,17 @@ export class GridCell extends BG3Component {
             if(itemData) {
                 this.element.dataset.actionType = itemData.system?.activation?.type?.toLowerCase() ?? itemData.activation?.type?.toLowerCase() ?? null;
                 this.element.dataset.itemType = itemData.type;
+
+                if (itemData.system?.activities) {
+                    const activityActionTypes = itemData.system.activities
+                      .values()
+                      .toArray()
+                      .filter((a) => !!a.activation?.type)
+                      .map((a) => a.activation.type);
+
+                    this.element.dataset.activityActionTypes = [...new Set(activityActionTypes)].join(',');
+                }
+
                 switch (itemData.type) {
                     case 'spell':
                         this.element.dataset.preparationMode = itemData.system.preparation?.mode;
@@ -351,3 +362,4 @@ export class GridCell extends BG3Component {
         }
     }
 }
+


### PR DESCRIPTION
#### A small change to allow highlighting on grid items when one of their activities matches the selected filter.

1. Adds `activityActionTypes` to the grid item dataset if the item has activities [`GridCell.js : 331-339`]
2. Modifies the search logic to include these in highlighting [`FilterContainer.js : 161`]

---

_Test activity_
![image](https://github.com/user-attachments/assets/9670c135-2947-417d-a4da-08a1c9eb7c96)

_With action filter on_
![image](https://github.com/user-attachments/assets/1c2be019-c355-4501-a4c8-8cab0fcfbe5f)

_With bonus action filter on_
![image](https://github.com/user-attachments/assets/39020ca6-adab-4bed-bd5f-947e6f3b9019)

