### PR TITLE
feat: add toggle to keep GM Hotbar visible when token is selected (#212)

### DIFF
--- a/scripts/bg3-hotbar.js
+++ b/scripts/bg3-hotbar.js
@@ -30,6 +30,7 @@ export class BG3Hotbar extends Application {
         // this.enabled = game.settings.get(BG3CONFIG.MODULE_NAME, 'uiEnabled');
         this.generateTimeout = null;
         this.colorPicker = null;
+        this.overrideGMHotbar = false;
 
         /** Hooks Event **/
         // Hooks.once("canvasReady", this._onCanvasReady.bind(this));
@@ -108,6 +109,9 @@ export class BG3Hotbar extends Application {
     }
 
     async _onControlToken(token, controlled) {
+        if (this.overrideGMHotbar && game.settings.get(BG3CONFIG.MODULE_NAME, 'enableGMHotbar')) {
+            return;
+        }
         if (!this.manager) return;
         
         if(this.generateTimeout) {


### PR DESCRIPTION
- Adds a toggle button to switch between GM Hotbar and Token Hotbar
- The toggle is only visible if 'Enable GM Hotbar' is active in settings
- Hotbar no longer automatically switches to token when override is active
- Refactors control buttons into smaller methods for better maintainability

## Related Issue
Closes #212
![image](https://github.com/user-attachments/assets/599dab8e-a9e3-4c58-9fcd-0735a47ad6b3)
![image](https://github.com/user-attachments/assets/4de9b480-a14a-494c-8c3e-bd9440c52479)
